### PR TITLE
Fix category slugs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Jay Oster <jay@kodewerx.org>"]
 repository = "https://github.com/parasyte/myn"
 edition = "2021"
 keywords = ["macros", "myn"]
-categories = ["parser-implementations", "procedural-macro-helpers"]
+categories = ["development-tools::procedural-macro-helpers", "parser-implementations"]
 license = "MIT"
 
 [dependencies]


### PR DESCRIPTION
- `cargo publish` only warns on invalid slugs when actually publishing. E.g. `--dry-run` did not catch this issue.