### PR TITLE
Replace unnecessary `format!()` invocations with `to_string()`

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -153,7 +153,7 @@ impl TokenTreeExt for Option<TokenTree> {
 
 impl LiteralExt for Literal {
     fn as_char(&self) -> Result<char, TokenStream> {
-        let string = format!("{self}");
+        let string = self.to_string();
         if !string.starts_with('\'') || !string.ends_with('\'') {
             return Err(spanned_error("Expected char literal", self.span()));
         }
@@ -166,7 +166,7 @@ impl LiteralExt for Literal {
     }
 
     fn as_string(&self) -> Result<String, TokenStream> {
-        let string = format!("{self}");
+        let string = self.to_string();
         if !string.starts_with('"') || !string.ends_with('"') {
             return Err(spanned_error("Expected string literal", self.span()));
         }


### PR DESCRIPTION
- Pointed out in: https://users.rust-lang.org/t/blog-post-improving-build-times-for-derive-macros-by-3x-or-more/92441/2