### PR TITLE
Replace `as_*` TokenIterExt methods with `try_*`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ license = "MIT"
 
 [dependencies]
 # No dependencies!
+
+[dev-dependencies]
+proc_macro = { package = "proc-macro2", version = "1" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,9 @@
 #![forbid(unsafe_code)]
 #![deny(clippy::all)]
 #![deny(clippy::pedantic)]
+#![cfg_attr(test, allow(clippy::cmp_owned))]
 
+#[cfg(not(test))]
 extern crate proc_macro;
 
 pub mod prelude;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -75,37 +75,53 @@ pub trait TokenIterExt: Iterator<Item = TokenTree> {
     /// `proc_macro` stream.
     fn expect_punct(&mut self, expect: char) -> Result<(), TokenStream>;
 
-    /// Parse the input as a group.
+    /// Try to parse the input as a group.
+    ///
+    /// This method should not consume the next item from the stream when an error is returned.
+    /// An implementation which always consumes will make it difficult for parsers to try
+    /// alternative matches.
     ///
     /// # Errors
     ///
     /// Returns a compiler error if parsing fails. The error should be inserted into the
     /// `proc_macro` stream.
-    fn as_group(&mut self) -> Result<Group, TokenStream>;
+    fn try_group(&mut self) -> Result<Group, TokenStream>;
 
-    /// Parse the input as an identifier.
+    /// Try to parse the input as an identifier.
+    ///
+    /// This method should not consume the next item from the stream when an error is returned.
+    /// An implementation which always consumes will make it difficult for parsers to try
+    /// alternative matches.
     ///
     /// # Errors
     ///
     /// Returns a compiler error if parsing fails. The error should be inserted into the
     /// `proc_macro` stream.
-    fn as_ident(&mut self) -> Result<Ident, TokenStream>;
+    fn try_ident(&mut self) -> Result<Ident, TokenStream>;
 
-    /// Parse the input as a literal.
+    /// Try to parse the input as a literal.
+    ///
+    /// This method should not consume the next item from the stream when an error is returned.
+    /// An implementation which always consumes will make it difficult for parsers to try
+    /// alternative matches.
     ///
     /// # Errors
     ///
     /// Returns a compiler error if parsing fails. The error should be inserted into the
     /// `proc_macro` stream.
-    fn as_lit(&mut self) -> Result<Literal, TokenStream>;
+    fn try_lit(&mut self) -> Result<Literal, TokenStream>;
 
-    /// Parse the input as punctuation.
+    /// Try to parse the input as punctuation.
+    ///
+    /// This method should not consume the next item from the stream when an error is returned.
+    /// An implementation which always consumes will make it difficult for parsers to try
+    /// alternative matches.
     ///
     /// # Errors
     ///
     /// Returns a compiler error if parsing fails. The error should be inserted into the
     /// `proc_macro` stream.
-    fn as_punct(&mut self) -> Result<Punct, TokenStream>;
+    fn try_punct(&mut self) -> Result<Punct, TokenStream>;
 }
 
 /// An extension trait for [`TokenTree`].

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -53,6 +53,9 @@ pub trait TokenIterExt: Iterator<Item = TokenTree> {
     ///
     /// Returns the group's inner [`TokenStream`] as a [`TokenIter`] when successful.
     ///
+    /// This method should always consume the next item from the stream, even when an error is
+    /// returned.
+    ///
     /// # Errors
     ///
     /// Returns a compiler error if parsing fails. The error should be inserted into the
@@ -61,6 +64,9 @@ pub trait TokenIterExt: Iterator<Item = TokenTree> {
 
     /// Parse the input as an identifier, expecting it to match the given string.
     ///
+    /// This method should always consume the next item from the stream, even when an error is
+    /// returned.
+    ///
     /// # Errors
     ///
     /// Returns a compiler error if parsing fails. The error should be inserted into the
@@ -68,6 +74,9 @@ pub trait TokenIterExt: Iterator<Item = TokenTree> {
     fn expect_ident(&mut self, expect: &str) -> Result<(), TokenStream>;
 
     /// Parse the input as punctuation, expecting it to match the given char.
+    ///
+    /// This method should always consume the next item from the stream, even when an error is
+    /// returned.
     ///
     /// # Errors
     ///

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -34,7 +34,7 @@ pub fn get_doc_comment(attrs: &[Attribute]) -> Vec<String> {
                     _ => return None,
                 }
 
-                tree.as_lit().and_then(|lit| lit.as_string()).ok()
+                tree.try_lit().and_then(|lit| lit.as_string()).ok()
             } else {
                 None
             }


### PR DESCRIPTION
The `as_*` methods always consume the item from the token stream, even if the item doesn't match the kind of token requested. This makes it very difficult for parsers to try multiple potential tokens.

This replaces these methods with "non-consuming" implementations that will leave the underlying iterator untouched when they return an error. This is a breaking change anyway, so the methods have been renamed to better reflect what they do.

- Adds tests
- Closes #7