### PR TITLE
Fix Literal::as_string() stripping indentation.

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -198,7 +198,6 @@ impl LiteralExt for Literal {
 
         // Strip double quotes and escapes.
         Ok(string[1..string.len() - 1]
-            .trim()
             .replace(r#"\""#, r#"""#)
             .replace(r"\n", "\n")
             .replace(r"\r", "\r")


### PR DESCRIPTION
This level of the abstraction should not concern itself with trimming whitespace. It's up to the caller to make that decision.