### PR TITLE
Support tuples and arrays in path parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "myn"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "proc-macro2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "myn"
 description = "Minimalist Rust syntax parsing for procedural macros"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Jay Oster <jay@kodewerx.org>"]
 repository = "https://github.com/parasyte/myn"
 edition = "2021"


### PR DESCRIPTION
Tuples and arrays can appear in paths. Examples:

```rust
struct Foo {
    tuple: (u8,),
    generic: foo::Bar<(Foo, bar::Baz)>,
    generic_complex: Foo<(Bar, [i32; 4])>,
}
```